### PR TITLE
29 admin merchant create

### DIFF
--- a/app/controllers/admin/merchants_controller.rb
+++ b/app/controllers/admin/merchants_controller.rb
@@ -23,6 +23,15 @@ class Admin::MerchantsController < ApplicationController
     
   end
 
+  def new
+    @merchant = Merchant.new
+  end
+
+  def create
+    @merchant = Merchant.create!(merchant_params)
+    redirect_to(admin_merchants_path)
+  end
+
   private 
 
   def merchant_params

--- a/app/models/merchant.rb
+++ b/app/models/merchant.rb
@@ -2,7 +2,7 @@ class Merchant < ApplicationRecord
   has_many :items
   has_many :invoice_items, through: :items
   has_many :invoices, through: :invoice_items
-  enum active_status: { enabled: 0, disabled: 1 }
+  enum active_status: { disabled: 0, enabled: 1 }
 
   def items_not_shipped_sorted_by_date
     invoices.where.not(invoice_items: {status: 2}).order("invoices.created_at")

--- a/app/views/admin/_merch_form.html.erb
+++ b/app/views/admin/_merch_form.html.erb
@@ -1,0 +1,5 @@
+<%= form_with model: [:admin, @merchant], local: true  do |form| %>
+    <%= form.label :name %>
+    <%= form.text_field :name %>
+    <%= form.submit %>
+<% end %>

--- a/app/views/admin/merchants/index.html.erb
+++ b/app/views/admin/merchants/index.html.erb
@@ -1,5 +1,5 @@
 <%= render partial: 'admin/header' %>
-
+<%= button_to "Create New Merchant", new_admin_merchant_path , method: :get %>
 <span id="enabled-merchants" style="float:left; padding:10px 60px 60px 60px;">
 <h3>Enabled Merchants</h3>
 

--- a/app/views/admin/merchants/new.html.erb
+++ b/app/views/admin/merchants/new.html.erb
@@ -1,4 +1,2 @@
 <%= render partial: 'admin/header' %>
 <%= render partial: 'admin/merch_form' %>
-
-  

--- a/spec/features/admin/merchants/edit_spec.rb
+++ b/spec/features/admin/merchants/edit_spec.rb
@@ -27,27 +27,28 @@ RSpec.describe "Admin Merchant Edit Page" do
         expect(current_path).to eq(edit_admin_merchant_path(@merchant_2))
       end
 
-      describe 
+      describe "Admin merchant Update page" do
       
-      it "I see a form filled in with the existing merchant attribute information" do 
-        visit edit_admin_merchant_path(@merchant_1)
-        expect(page).to have_field("Name", {with: "#{@merchant_1.name}"})
-        expect(page).to_not have_field("Name", {with: "#{@merchant_2.name}"})
+        it "I see a form filled in with the existing merchant attribute information" do 
+          visit edit_admin_merchant_path(@merchant_1)
+          expect(page).to have_field("Name", {with: "#{@merchant_1.name}"})
+          expect(page).to_not have_field("Name", {with: "#{@merchant_2.name}"})
 
-        visit edit_admin_merchant_path(@merchant_2)
-        expect(page).to have_field("Name", {with: "#{@merchant_2.name}"})
-      end
+          visit edit_admin_merchant_path(@merchant_2)
+          expect(page).to have_field("Name", {with: "#{@merchant_2.name}"})
+        end
 
-      it "When I update the information in the form and I click ‘submit’, I am redirected back to the merchant's admin show page where I see the updated information and I see a flash message stating that the information has been successfully updated" do
-        visit edit_admin_merchant_path(@merchant_1)
+        it "When I update the information in the form and I click 'submit', I am redirected back to the merchant's admin show page where I see the updated information and I see a flash message stating that the information has been successfully updated" do
+          visit edit_admin_merchant_path(@merchant_1)
 
-        fill_in "Name",	with: "Billy John Tools"
-        click_button"Update Merchant"
+          fill_in "Name",	with: "Billy John Tools"
+          click_button"Update Merchant"
 
-        expect(current_path).to eq(admin_merchant_path(@merchant_1))
-        expect(page).to have_content("Billy John Tools")
-        expect(page).to_not have_content("Johns Tools")
-        expect(page).to have_content ("Merchant was successfully updated!")
+          expect(current_path).to eq(admin_merchant_path(@merchant_1))
+          expect(page).to have_content("Billy John Tools")
+          expect(page).to_not have_content("Johns Tools")
+          expect(page).to have_content ("Merchant was successfully updated!")
+        end
       end
     end
   end

--- a/spec/features/admin/merchants/index_spec.rb
+++ b/spec/features/admin/merchants/index_spec.rb
@@ -111,23 +111,6 @@ RSpec.describe "Admin Merchants" do
         end
       end
 
-#       Admin Merchant Create
-
-# As an admin,
-# When I visit the admin merchants index
-# I see a link to create a new merchant.
-# When I click on the link,
-# I am taken to a form that allows me to add merchant information.
-# When I fill out the form I click ‘Submit’
-# Then I am taken back to the admin merchants index page
-# And I see the merchant I just created displayed
-# And I see my merchant was created with a default status of disabled.
-
-      it 'US#29 - Admin Merchant Create' do
-        visit admin_merchants_path
-
-      end
-      
     end
   end
 end

--- a/spec/features/admin/merchants/index_spec.rb
+++ b/spec/features/admin/merchants/index_spec.rb
@@ -4,11 +4,11 @@ RSpec.describe "Admin Merchants" do
   describe "As an admin" do
     describe "I visit the admin merchants index (/admin/merchants)" do
       before :each do
-        @merchant_1 = Merchant.create!(name: "Johns Tools")
-        @merchant_2 = Merchant.create!(name: "Hannas Hammocks")
-        @merchant_3 = Merchant.create!(name: "Pretty Plumbing", active_status: :disabled)
-        @merchant_4 = Merchant.create!(name: "Jenna's Jewlery")
-        @merchant_5 = Merchant.create!(name: "Sassy Soap", active_status: :disabled)
+        @merchant_1 = Merchant.create!(name: "Johns Tools", active_status: :enabled)
+        @merchant_2 = Merchant.create!(name: "Hannas Hammocks", active_status: :enabled)
+        @merchant_3 = Merchant.create!(name: "Pretty Plumbing")
+        @merchant_4 = Merchant.create!(name: "Jenna's Jewlery", active_status: :enabled)
+        @merchant_5 = Merchant.create!(name: "Sassy Soap")
       end
   
       it 'can see the name of each merchant in the system' do

--- a/spec/features/admin/merchants/new_spec.rb
+++ b/spec/features/admin/merchants/new_spec.rb
@@ -1,0 +1,47 @@
+require 'rails_helper'
+
+RSpec.describe "Admin Merchant Create New" do
+  describe "As an admin" do
+    describe "When I visit the admin merchants index" do
+      before :each do
+          @merchant_1 = Merchant.create!(name: "Johns Tools")
+          @merchant_2 = Merchant.create!(name: "Hannas Hammocks")
+      end
+
+
+          #       Admin Merchant Create
+
+      # As an admin,
+      # I see a link to create a new merchant.
+      # When I click on the link,
+
+      # I am taken to a form that allows me to add merchant information.
+      # When I fill out the form I click ‘Submit’
+      # Then I am taken back to the admin merchants index page
+      # And I see the merchant I just created displayed
+      # And I see my merchant was created with a default status of disabled.
+
+      it 'US#29 - Admin Merchant Create - new path' do
+        visit admin_merchants_path
+
+        click_button "Create New Merchant"
+        expect(current_path).to eq(new_admin_merchant_path)
+      end
+
+
+      it "will take us to the form to add merchant info" do
+
+        visit new_admin_merchant_path
+
+        fill_in "Name", with: "Billy Bobs Burgers"
+        click_button "Submit"
+
+        expect(current_path).to eq(admin_merchants_path)
+        within("#disabled-merchants") do
+          expect(page).to have_content("Billy Bobs Burgers")
+        end
+      end
+      
+    end
+  end
+end

--- a/spec/features/admin/merchants/new_spec.rb
+++ b/spec/features/admin/merchants/new_spec.rb
@@ -3,11 +3,6 @@ require 'rails_helper'
 RSpec.describe "Admin Merchant Create New" do
   describe "As an admin" do
     describe "When I visit the admin merchants index" do
-      before :each do
-          @merchant_1 = Merchant.create!(name: "Johns Tools")
-          @merchant_2 = Merchant.create!(name: "Hannas Hammocks")
-      end
-
 
           #       Admin Merchant Create
 
@@ -34,14 +29,13 @@ RSpec.describe "Admin Merchant Create New" do
         visit new_admin_merchant_path
 
         fill_in "Name", with: "Billy Bobs Burgers"
-        click_button "Submit"
+        click_button "Create Merchant"
 
         expect(current_path).to eq(admin_merchants_path)
         within("#disabled-merchants") do
           expect(page).to have_content("Billy Bobs Burgers")
         end
       end
-      
     end
   end
 end

--- a/spec/models/merchant_spec.rb
+++ b/spec/models/merchant_spec.rb
@@ -7,12 +7,12 @@ RSpec.describe Merchant, type: :model do
 
   describe 'Class Methods' do
     before :each do
-      @merchant_1 = Merchant.create!(name: "Johns Tools")
-        @merchant_2 = Merchant.create!(name: "Hannas Hammocks")
-        @merchant_3 = Merchant.create!(name: "Pretty Plumbing", active_status: :disabled)
-        @merchant_4 = Merchant.create!(name: "Jenna's Jewlery")
-        @merchant_5 = Merchant.create!(name: "Sassy Soap", active_status: :disabled)
-        @merchant_6 = Merchant.create!(name: "Tom's Typewriters", active_status: :disabled)
+      @merchant_1 = Merchant.create!(name: "Johns Tools", active_status: :enabled)
+      @merchant_2 = Merchant.create!(name: "Hannas Hammocks", active_status: :enabled)
+      @merchant_3 = Merchant.create!(name: "Pretty Plumbing")
+      @merchant_4 = Merchant.create!(name: "Jenna's Jewlery", active_status: :enabled)
+      @merchant_5 = Merchant.create!(name: "Sassy Soap")
+      @merchant_6 = Merchant.create!(name: "Tom's Typewriters")
     end
 
     it "#active" do


### PR DESCRIPTION
Completed US#29 
Admin Merchant Create

As an admin,
When I visit the admin merchants index
I see a link to create a new merchant.
When I click on the link,
I am taken to a form that allows me to add merchant information.
When I fill out the form I click ‘Submit’
Then I am taken back to the admin merchants index page
And I see the merchant I just created displayed
And I see my merchant was created with a default status of disabled.

and refactored admin/merchant/#edit and #new to have a form partial